### PR TITLE
The length of generated string is wrong

### DIFF
--- a/Hashids/Classes/Hashids.m
+++ b/Hashids/Classes/Hashids.m
@@ -314,7 +314,7 @@ static NSString * const DEFAULT_SALT = @"";
         if(excess > 0){
             int start_pos = excess / 2;
             
-            ret_str = [[ret_str substringWithRange:NSMakeRange(start_pos, start_pos + minHashLength)] mutableCopy];
+            ret_str = [[ret_str substringWithRange:NSMakeRange(start_pos,  minHashLength)] mutableCopy];
         }
     }
     


### PR DESCRIPTION
**Bug:** 
The problem is that the strings generated with minLength assigned are always with wrong lengths. 

**Solution**
I remove the variable start_pos from the second paremeter of NSRange to ensure the length is right.
